### PR TITLE
Changed exit on ^C from status=1 to status=0 since ^C is the normal …

### DIFF
--- a/Clock.py
+++ b/Clock.py
@@ -87,4 +87,4 @@ try:
         time.sleep(24*3600 - now)  # wait until midnight and start over
 except KeyboardInterrupt:
     print()
-    sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
…exit path for the Clock program's otherwise infinite loop.

BTW, as for the KeyboardInterrupt handling - any thoughts about the span of that "try ... except" block? I purposely covered all code, including the "import ..." and beyond since it's all executed and ought to be on guard. OTOH I could see omitting it from the setup/initialization and only adding it, say, around the "while True: ..." loop, letting other code go unprotected? It seems strange to be doing the "import" etc. inside a "try" block but that may just be my seeing it through a C/C++ "#include ..." lens?