### PR TITLE
Pwd 16 clock announce timing

### DIFF
--- a/Clock.py
+++ b/Clock.py
@@ -130,7 +130,9 @@ try:
     
     port = args.Port # serial port for KOB interface
     speed = args.Speed  # code speed (words per minute)
+    print("args.Sound is", args.Sound)
     sound = True if args.Sound == 'ON' else False
+    print("sound =", sound)
     start_time = hms_to_seconds(int(args.Begin/100), args.Begin % 100, 0)  # start time (sec)
     end_time = hms_to_seconds(int(args.End/100), args.End % 100, 0)  # end time (sec)
     annc_interval = args.Interval * 60      # announcement interval (sec)

--- a/Clock.py
+++ b/Clock.py
@@ -110,7 +110,7 @@ def announcement(hours, minutes):
 # Send a message as morse on the sounder:
 #
 def announce(s, kob, sender):
-    print("> ", s)
+    print(">", s)
     for c in s:
         code = sender.encode(c)
         kob.sounder(code)
@@ -150,16 +150,16 @@ try:
         next_time = round_up(hms_to_seconds(t.tm_hour, t.tm_min, t.tm_sec), annc_interval)  # next announcement (sec)
         if next_time < start_time:
             next_time = start_time
-        print("Next time announcement at {0}:{1:02d}".format(clock_hour(next_time), clock_minutes(next_time)))
+        # print("Next time announcement at {0}:{1:02d}".format(clock_hour(next_time), clock_minutes(next_time)))
         now = hms_to_seconds(t.tm_hour, t.tm_min, t.tm_sec)  # current time (sec)
         if next_time <= end_time:
             if now < next_time:
-                print("sleeping for {0} seconds until next time announcement...".format(next_time - now))
+                # print("sleeping for {0} seconds until next time announcement...".format(next_time - now))
                 time.sleep(next_time - now)
             msg = announcement(clock_hour(next_time), clock_minutes(next_time))
             announce(msg, myKOB, mySender)
         else:
-            print("sleeping for {0} seconds until midnight...")
+            # print("sleeping for {0} seconds until midnight...")
             time.sleep(24*3600 - now)  # wait until midnight and start over
 except KeyboardInterrupt:
     print()

--- a/Clock.py
+++ b/Clock.py
@@ -130,9 +130,7 @@ try:
     
     port = args.Port # serial port for KOB interface
     speed = args.Speed  # code speed (words per minute)
-    print("args.Sound is", args.Sound)
     sound = True if args.Sound == 'ON' else False
-    print("sound =", sound)
     start_time = hms_to_seconds(int(args.Begin/100), args.Begin % 100, 0)  # start time (sec)
     end_time = hms_to_seconds(int(args.End/100), args.End % 100, 0)  # end time (sec)
     annc_interval = args.Interval * 60      # announcement interval (sec)

--- a/Clock.py
+++ b/Clock.py
@@ -30,7 +30,7 @@ Clock.py
 Cuckoo clock substitute.
 
 Serial port, code speed, and audio preferences should be specified by running the
-'configure.sh' script or executing 'python3 Configure.py'.
+"configure.sh" script or executing "python3 Configure.py".
 """
 
 NUMBER = [ "oh", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve"]
@@ -42,7 +42,7 @@ def hms_to_seconds(hours, minutes, seconds):
     return hours * 3600 + minutes * 60 + seconds
 
 #
-# Convert from numeric representation to text ('9' to 'nine')
+# Convert from numeric representation to text ("9" to "nine")
 #
 def number_to_text(n):
     if (n < 0) or ( n > 12):
@@ -79,7 +79,7 @@ def round_up(start, interval):
 # Generate a proper time announcement:
 #
 #   "midnight"
-#   "Nine o'clock"
+#   "Nine o"clock"
 #   "A quarter past nine"
 #   "9:20"
 #   "Half past nine"
@@ -94,13 +94,13 @@ def announcement(hours, minutes):
         elif hours == 12:
             msg += "noon" + 12 * "L "
         else:
-            msg += number_to_text(truncate_hours(hours)) + " oclock     " + hours * "L "
+            msg += number_to_text(truncate_hours(hours)) + " o'clock     " + truncate_hours(hours) * "L "
     elif minutes == 15:
         msg += "a quarter past " + number_to_text(truncate_hours(hours))
     elif minutes == 30:
         msg += "half past " + number_to_text(truncate_hours(hours))
     elif minutes == 45:
-        msg += "a quarter to " + numer_to_text(truncate_hours(hours + 1))
+        msg += "a quarter to " + number_to_text(truncate_hours(hours + 1))
     else:
         # Last resort: just generate the time in hh:mm format
         msg += "{hour}:{minute:02d}".format(hour=hours, minute=minutes)
@@ -121,12 +121,12 @@ try:
     import time
     from pykob import config, kob, morse, log
 
-    log.log('Starting Clock')
+    log.log("Starting Clock")
 
     clock_parser = argparse.ArgumentParser(parents=[config.WPM_OVERRIDE])
-    clock_parser.add_argument('-b', '--begin', default=900, type=int, help='Beginning of time announcements ', metavar='time', dest='Begin')
-    clock_parser.add_argument('-e', '--end', default=2230, type=int, help='End of time announcements ', metavar='time', dest='End')
-    clock_parser.add_argument('-i', '--interval', default=60, type=int, help='The time announcement interval in minutes', metavar='minutes', dest='Interval')
+    clock_parser.add_argument("-b", "--begin", default=900, type=int, help="Beginning of time announcements ", metavar="time", dest="Begin")
+    clock_parser.add_argument("-e", "--end", default=2230, type=int, help="End of time announcements ", metavar="time", dest="End")
+    clock_parser.add_argument("-i", "--interval", default=60, type=int, help="The time announcement interval in minutes", metavar="minutes", dest="Interval")
     args = clock_parser.parse_args()
     
     PORT = config.Port # serial port for KOB interface

--- a/pykob/config.py
+++ b/pykob/config.py
@@ -183,8 +183,7 @@ def readConfig():
     global Port
     global Sound
     global Speed
-#   global WIRE_OVERRIDE
-    global WPM_OVERRIDE
+    global WPM_Override
 
     # Get the system data
     try:
@@ -234,7 +233,7 @@ def readConfig():
             Port = None
 
         # Get the User config values
-        Sound = userConfig.getboolean(configSection, 'SOUND')
+        Sound = userConfig.get(configSection, 'SOUND')
         Speed = userConfig.getint(configSection, 'SPEED')
     except KeyError as ex:
         log.err("Key '{}' not found in configuration file.".format(ex.args[0]))
@@ -245,10 +244,13 @@ def readConfig():
 # ### Mainline
 readConfig()
 
-# WIRE_OVERRIDE = argparse.ArgumentParser(add_help=False)
-# WIRE_OVERRIDE.add_argument('-w', '--wire', type=int, help='The wire to connect to', metavar='wire', dest='Wire')
+PortOverride = argparse.ArgumentParser(add_help=False)
+PortOverride.add_argument("-p", "--port", default=Port, help="The  name of the serial port to use ", metavar="portname", dest="Port")
 
-WPM_OVERRIDE = argparse.ArgumentParser(add_help=False)
-WPM_OVERRIDE.add_argument('-s', '--speed', default=Speed, type=int, help='The  morse send speed in WPM', metavar='speed', dest='Speed')
+SoundtOverride = argparse.ArgumentParser(add_help=False)
+SoundtOverride.add_argument("-a", "--sound", default=Sound, choices=['ON', 'OFF'], help="'ON' or 'OFF' to indicate whether morse audio should be generated", metavar="sound", dest="Sound")
+
+WPMOverride = argparse.ArgumentParser(add_help=False)
+WPMOverride.add_argument("-s", "--speed", default=Speed, type=int, help="The  morse send speed in WPM", metavar="speed", dest="Speed")
 
 exit

--- a/pykob/config.py
+++ b/pykob/config.py
@@ -45,6 +45,7 @@ The files are INI format with the values in a section named 'PYKOB'.
 
 """
 
+import argparse
 import configparser
 import distutils
 import getpass
@@ -182,6 +183,8 @@ def readConfig():
     global Port
     global Sound
     global Speed
+#   global WIRE_OVERRIDE
+    global WPM_OVERRIDE
 
     # Get the system data
     try:
@@ -241,4 +244,11 @@ def readConfig():
 
 # ### Mainline
 readConfig()
+
+# WIRE_OVERRIDE = argparse.ArgumentParser(add_help=False)
+# WIRE_OVERRIDE.add_argument('-w', '--wire', type=int, help='The wire to connect to', metavar='wire', dest='Wire')
+
+WPM_OVERRIDE = argparse.ArgumentParser(add_help=False)
+WPM_OVERRIDE.add_argument('-s', '--speed', default=Speed, type=int, help='The  morse send speed in WPM', metavar='speed', dest='Speed')
+
 exit

--- a/pykob/config.py
+++ b/pykob/config.py
@@ -183,7 +183,9 @@ def readConfig():
     global Port
     global Sound
     global Speed
-    global WPM_Override
+    global PortOverride
+    global SoundtOverride
+    global WPMOverride
 
     # Get the system data
     try:

--- a/pykob/config.py
+++ b/pykob/config.py
@@ -235,7 +235,7 @@ def readConfig():
             Port = None
 
         # Get the User config values
-        Sound = userConfig.get(configSection, 'SOUND')
+        Sound = userConfig.getboolean(configSection, 'SOUND')
         Speed = userConfig.getint(configSection, 'SPEED')
     except KeyError as ex:
         log.err("Key '{}' not found in configuration file.".format(ex.args[0]))
@@ -250,7 +250,7 @@ PortOverride = argparse.ArgumentParser(add_help=False)
 PortOverride.add_argument("-p", "--port", default=Port, help="The  name of the serial port to use ", metavar="portname", dest="Port")
 
 SoundtOverride = argparse.ArgumentParser(add_help=False)
-SoundtOverride.add_argument("-a", "--sound", default=Sound, choices=['ON', 'OFF'], help="'ON' or 'OFF' to indicate whether morse audio should be generated", metavar="sound", dest="Sound")
+SoundtOverride.add_argument("-a", "--sound", default='ON' if Sound else 'OFF', choices=['ON', 'OFF'], help="'ON' or 'OFF' to indicate whether morse audio should be generated", metavar="sound", dest="Sound")
 
 WPMOverride = argparse.ArgumentParser(add_help=False)
 WPMOverride.add_argument("-s", "--speed", default=Speed, type=int, help="The  morse send speed in WPM", metavar="speed", dest="Speed")


### PR DESCRIPTION
This change restructures the Clock.py program to be able to announce on arbitrary intervals and in more natural formats:

   "midnight"
   "Nine o"clock"
   "A quarter past nine"
   "9:20"
   "Half past nine"
   "A quarter to ten"
   "noon"

In the process I've created an experiment in the command line parsing, changing 'config.py' to create overrides for the options defined in the config file and changing Clock.py to builds its command line parser with the defaults as they're set in the config file but with the option to override them.

In addition I added an 'argsparser'-based command line parser for Clock-specific options:
    -b \<begin time\>
    -e \<end time\>
    -i \<interval\>

The idea being you can start the clock with

    python3 Clock.py -s 20 -i 15 -a OFF

to start it running at 20 WPM (regardless of configured defaults), at 15 minute intervals, with the audio always OFF, on the default configured port.

I'd welcome all comments, especially on choices of variable and global names.  Existing code had some all-caps variables, and ideal choice of case for globals in 'config' is unclear to me.