### PR TITLE
Add KeyboardInterrupt guard in main code block of all programs

### DIFF
--- a/Clock.py
+++ b/Clock.py
@@ -191,4 +191,4 @@ try:
             time.sleep(24*3600 - now)  # wait until midnight and start over
 except KeyboardInterrupt:
     print()
-    sys.exit(0)
+    sys.exit(0)     # Since normal operation is an infinite loop, ^C is actually a normal exit.

--- a/Configure.py
+++ b/Configure.py
@@ -115,4 +115,8 @@ def main(argv):
     exit
 
 if __name__ == "__main__":
-   main(sys.argv[1:])
+    try:
+        main(sys.argv[1:])
+    except KeyboardInterrupt:
+        print()
+        sys.exit(1)     # Indicate this was an abnormal exit

--- a/Feed.py
+++ b/Feed.py
@@ -67,7 +67,6 @@ Feed 1.4  2018-07-10
 - converted from legacy morsekob module to use pykob module
 
 """
-
 import sys
 import time, datetime
 import threading
@@ -118,29 +117,33 @@ def send(code):
     myInternet.write(code)
     myKOB.sounder(code)  # to pace the code sent to the wire
 
-while True:
-    articles = newsreader.getArticles(url)
-    for (title, description, pubDate) in articles:
-        if days and pubDate:
-            today = datetime.date.today()
-            pd = datetime.datetime.strptime(pubDate[:-6], DATEFORMAT).date()
-            if pd > today or today - pd >= datetime.timedelta(days):
-                continue
-        text = ''
-        if title:
-            text += title + '. '
-        text += description
-        if pubDate:  # treat as an article, not freeform text
-            text += '  ='
-        while activeSender() or not activeListener():
-            time.sleep(1)
-        send((-0x7fff, +2, -1000, +2))  # open circuit and wait 1 sec
-        for char in text:
-            if activeSender() or not activeListener():
-                break
-            code = mySender.encode(char)
-            if code:
-                send(code)
-        send((-1000, +1))  # close circuit after 1 sec
-        time.sleep(artPause)
-    time.sleep(grpPause - artPause)
+try:
+    while True:
+        articles = newsreader.getArticles(url)
+        for (title, description, pubDate) in articles:
+            if days and pubDate:
+                today = datetime.date.today()
+                pd = datetime.datetime.strptime(pubDate[:-6], DATEFORMAT).date()
+                if pd > today or today - pd >= datetime.timedelta(days):
+                    continue
+            text = ''
+            if title:
+                text += title + '. '
+            text += description
+            if pubDate:  # treat as an article, not freeform text
+                text += '  ='
+            while activeSender() or not activeListener():
+                time.sleep(1)
+            send((-0x7fff, +2, -1000, +2))  # open circuit and wait 1 sec
+            for char in text:
+                if activeSender() or not activeListener():
+                    break
+                code = mySender.encode(char)
+                if code:
+                    send(code)
+            send((-1000, +1))  # close circuit after 1 sec
+            time.sleep(artPause)
+        time.sleep(grpPause - artPause)
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since normal operation is an infinite loop, ^C is actually a normal exit.

--- a/News.py
+++ b/News.py
@@ -48,20 +48,24 @@ PAUSE    = 5  # gap to leave between articles (seconds)
 mySender = morse.Sender(WPM, CWPM, morse.INTERNATIONAL, morse.CHARSPACING)
 myKOB = kob.KOB(PORT, SOUND)
 
-while True:
-    print('')
-    articles = newsreader.getArticles(SOURCE)
-    for (title, description, pubDate) in articles:
-        text = title + ' = ' + description + ' ='
-        for char in text:
-            code = mySender.encode(char)
-            myKOB.sounder(code)
-            if code:
-                sys.stdout.write(char)
-            else:
-                sys.stdout.write(' ')
-            sys.stdout.flush()
-            if char == '=':
-                print('')
+try:
+    while True:
         print('')
-        time.sleep(PAUSE)
+        articles = newsreader.getArticles(SOURCE)
+        for (title, description, pubDate) in articles:
+            text = title + ' = ' + description + ' ='
+            for char in text:
+                code = mySender.encode(char)
+                myKOB.sounder(code)
+                if code:
+                    sys.stdout.write(char)
+                else:
+                    sys.stdout.write(' ')
+                sys.stdout.flush()
+                if char == '=':
+                    print('')
+            print('')
+            time.sleep(PAUSE)
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since normal operation is an infinite loop, ^C is actually a normal exit.

--- a/Receive.py
+++ b/Receive.py
@@ -45,20 +45,6 @@ from time import sleep
 from pykob import VERSION, config, internet, morse
 import codecs
 
-WIRE     = 109  # default KOB wire to connect to
-WPM      = config.Speed  # code speed (words per minute)
-OFFICEID = 'MorseKOB 4.0 test, AC (listening)'
-THINSPACE = '\u202F'  # narrow (half width) non-breaking space
-
-print('Python ' + sys.version + ' on ' + sys.platform)
-print('MorseKOB ' + VERSION)
-
-# get command line parameters, if any
-if len(sys.argv) > 1:
-    WIRE = int(sys.argv[1])
-if len(sys.argv) > 2:
-    WPM = int(sys.argv[2])
-
 def readerCallback(char, spacing):
 ##    outFile.write('{} {}\n'.format(spacing, char))
 ##    return
@@ -73,11 +59,29 @@ def readerCallback(char, spacing):
         outFile.write(' ')
     outFile.write(char)
 
-myInternet = internet.Internet(OFFICEID)
-myReader = morse.Reader(callback=readerCallback)
-myInternet.connect(WIRE)
-outFile = codecs.open( "log.txt", "w", "utf-8" )
-sleep(0.5)
-while True:
-    code = myInternet.read()
-    myReader.decode(code)
+try:
+    WIRE     = 109  # default KOB wire to connect to
+    WPM      = config.Speed  # code speed (words per minute)
+    OFFICEID = 'MorseKOB 4.0 test, AC (listening)'
+    THINSPACE = '\u202F'  # narrow (half width) non-breaking space
+
+    print('Python ' + sys.version + ' on ' + sys.platform)
+    print('MorseKOB ' + VERSION)
+
+    # get command line parameters, if any
+    if len(sys.argv) > 1:
+        WIRE = int(sys.argv[1])
+    if len(sys.argv) > 2:
+        WPM = int(sys.argv[2])
+
+    myInternet = internet.Internet(OFFICEID)
+    myReader = morse.Reader(callback=readerCallback)
+    myInternet.connect(WIRE)
+    outFile = codecs.open( "log.txt", "w", "utf-8" )
+    sleep(0.5)
+    while True:
+        code = myInternet.read()
+        myReader.decode(code)
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since the main program is an infinite loop, ^C is a normal, successful exit.

--- a/Sample.py
+++ b/Sample.py
@@ -40,20 +40,24 @@ WPM = config.Speed  # code speed (words per minute)
 SOUND = config.Sound # whether to enable computer sound for sounder
 TEXT = '~ The quick brown fox +'  # ~ opens the circuit, + closes it
 
-myKOB = kob.KOB(PORT, audio=SOUND)
-mySender = morse.Sender(WPM)
+try:
+    myKOB = kob.KOB(PORT, audio=SOUND)
+    mySender = morse.Sender(WPM)
 
-# send HI at 20 wpm as an example
-print("HI");
-code = (-1000, +2, -1000, +60, -60, +60, -60, +60, -60, +60,
-        -180, +60, -60, +60, -1000, +1)
-myKOB.sounder(code)
-time.sleep(2)
-
-# then send the text
-print(TEXT);
-for c in TEXT:
-    code = mySender.encode(c)
+    # send HI at 20 wpm as an example
+    print("HI");
+    code = (-1000, +2, -1000, +60, -60, +60, -60, +60, -60, +60,
+            -180, +60, -60, +60, -1000, +1)
     myKOB.sounder(code)
+    time.sleep(2)
 
-time.sleep(1)
+    # then send the text
+    print(TEXT);
+    for c in TEXT:
+        code = mySender.encode(c)
+        myKOB.sounder(code)
+
+    time.sleep(1)
+except KeyboardInterrupt:
+    print()
+    sys.exit(1)     # Indicate this was an abnormal exit

--- a/SchedFeed.py
+++ b/SchedFeed.py
@@ -77,20 +77,24 @@ if WIRE:
     myInternet.connect(WIRE)
 mySender = morse.Sender(WPM)
 
-while True:
-    for m in msgs:
-        t0 = time.localtime()
-        now = t0.tm_hour*3600 + t0.tm_min*60 + t0.tm_sec  # current time (sec)
-        t1, s = m
-        tMsg = 3600*(t1//100) + 60*(t1%100)  # time to send message
-        dt = tMsg - now  # time to wait
-        if dt > 0:
-            time.sleep(dt)
-            for c in s:
-                code = mySender.encode(c)
-                myKOB.sounder(code)  # to pace the code sent to the wire
-                if WIRE:
-                    myInternet.write(code)
-                print(c, end='', flush=True)  # display each character
-            print(flush=True)  # start new line after each message
-    time.sleep(24*3600 - now)  # wait until midnight and start over
+try:
+    while True:
+        for m in msgs:
+            t0 = time.localtime()
+            now = t0.tm_hour*3600 + t0.tm_min*60 + t0.tm_sec  # current time (sec)
+            t1, s = m
+            tMsg = 3600*(t1//100) + 60*(t1%100)  # time to send message
+            dt = tMsg - now  # time to wait
+            if dt > 0:
+                time.sleep(dt)
+                for c in s:
+                    code = mySender.encode(c)
+                    myKOB.sounder(code)  # to pace the code sent to the wire
+                    if WIRE:
+                        myInternet.write(code)
+                    print(c, end='', flush=True)  # display each character
+                print(flush=True)  # start new line after each message
+        time.sleep(24*3600 - now)  # wait until midnight and start over
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since normal operation is an infinite loop, ^C is actually a normal exit.

--- a/Time.py
+++ b/Time.py
@@ -58,86 +58,90 @@ Time 1.3  2019-02-13
 
 """
 
-import sys
-import time
-import threading
-from pykob import config,log, kob, internet
-
-VERSION = '1.4'
-PORT    = config.Port # serial port for KOB interface
-SOUND   = config.Sound # whether to enable computer sound for sounder
-TIMEOUT = 30.0  # time to send after last indication of live listener (sec)
-TICK    = (-1, +1, -200, +1, -200, +2) + 3 * (-200, +2)
-NOTICK  = 5 * (-200, +2)
-MARK    = (-1, +1) + 9 * (-200, +1) + (-200, +2)
-
-log.log('Starting Time {0}'.format(VERSION))
-
-nargs = len(sys.argv)
-mode = sys.argv[1][0] if nargs > 1 else 'c'
-if nargs > 2:
-    wire = int(sys.argv[2])
-    idText = sys.argv[3]
-else:
-    wire = None
-
-myKOB = kob.KOB(PORT, SOUND)
-
-if wire:
-    myInternet = internet.Internet(idText)
-    myInternet.connect(wire)
-    time.sleep(1)
-
-    def checkForListener():
-        while True:
-            myInternet.read()  # activate the reader to get tLastListener updates
-            
-    listenerThread = threading.Thread(target=checkForListener)
-    listenerThread.daemon = True
-    listenerThread.start()
-
 def send(code):
     if wire and time.time() < myInternet.tLastListener + TIMEOUT:
         myInternet.write(code)
     myKOB.sounder(code)
 
-while True:
-    now = time.gmtime()
-    hh = now.tm_hour
-    mm = now.tm_min
-    ss = now.tm_sec
-    time.sleep(60 - ss)  # wait for the top of the minute
-    nn = (mm + 1) % 5  # nn: minute 0 to minute 5
-    if mode == 'c' or mode == 'h' and mm == 59 or \
-            mode == 'd' and hh == 16 and mm >= 55:
-        if mode == 'h':
-            send(MARK)
-        elif nn == 0:
-            send(MARK)
-            for i in range(7):
-                send(NOTICK)
-            send((-1, +1))  # close the circuit
-        elif nn == 1:
-            time.sleep(55)
-            send((-1, +2))  # open the circuit
-        else:
-            for i in range(29):
-                send(TICK)
-            send(NOTICK)
-            for i in range(21):
-                send(TICK)
-            if nn == 2:
-                for i in range(2):
-                    send(TICK)
-                send(NOTICK)
-                for i in range(2):
-                    send(TICK)
-            elif nn == 3:
-                for i in range(2):
-                    send(TICK)
-                for i in range(2):
+try:
+    import sys
+    import time
+    import threading
+    from pykob import config,log, kob, internet
+
+    VERSION = '1.4'
+    PORT    = config.Port # serial port for KOB interface
+    SOUND   = config.Sound # whether to enable computer sound for sounder
+    TIMEOUT = 30.0  # time to send after last indication of live listener (sec)
+    TICK    = (-1, +1, -200, +1, -200, +2) + 3 * (-200, +2)
+    NOTICK  = 5 * (-200, +2)
+    MARK    = (-1, +1) + 9 * (-200, +1) + (-200, +2)
+
+    log.log('Starting Time {0}'.format(VERSION))
+
+    nargs = len(sys.argv)
+    mode = sys.argv[1][0] if nargs > 1 else 'c'
+    if nargs > 2:
+        wire = int(sys.argv[2])
+        idText = sys.argv[3]
+    else:
+        wire = None
+
+    myKOB = kob.KOB(PORT, SOUND)
+
+    if wire:
+        myInternet = internet.Internet(idText)
+        myInternet.connect(wire)
+        time.sleep(1)
+
+        def checkForListener():
+            while True:
+                myInternet.read()  # activate the reader to get tLastListener updates
+            
+        listenerThread = threading.Thread(target=checkForListener)
+        listenerThread.daemon = True
+        listenerThread.start()
+
+    while True:
+        now = time.gmtime()
+        hh = now.tm_hour
+        mm = now.tm_min
+        ss = now.tm_sec
+        time.sleep(60 - ss)  # wait for the top of the minute
+        nn = (mm + 1) % 5  # nn: minute 0 to minute 5
+        if mode == 'c' or mode == 'h' and mm == 59 or \
+                mode == 'd' and hh == 16 and mm >= 55:
+            if mode == 'h':
+                send(MARK)
+            elif nn == 0:
+                send(MARK)
+                for i in range(7):
                     send(NOTICK)
-                send(TICK)
-            elif nn == 4:
-                for i in range(5):
+                send((-1, +1))  # close the circuit
+            elif nn == 1:
+                time.sleep(55)
+                send((-1, +2))  # open the circuit
+            else:
+                for i in range(29):
+                    send(TICK)
+                send(NOTICK)
+                for i in range(21):
+                    send(TICK)
+                if nn == 2:
+                    for i in range(2):
+                        send(TICK)
                     send(NOTICK)
+                    for i in range(2):
+                        send(TICK)
+                elif nn == 3:
+                    for i in range(2):
+                        send(TICK)
+                    for i in range(2):
+                        send(NOTICK)
+                    send(TICK)
+                elif nn == 4:
+                    for i in range(5):
+                        send(NOTICK)
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since the main program is an infinite loop, ^C is a normal, successful exit.

--- a/Weather.py
+++ b/Weather.py
@@ -56,11 +56,7 @@ Change history:
 - initial release
 
 """
-
-try:
-    from urllib.request import Request, urlopen  # Python 3
-except:
-    from urllib2 import Request, urlopen  # Python 2
+from urllib.request import Request, urlopen  # Python 3
 import re
 import time
 from pykob import internet, morse, kob, log
@@ -208,33 +204,37 @@ def send(text):
         myKOB.sounder(code)  # to pace the code sent to the wire
         myInternet.write(code)
 
-if DEBUG:
-    print(DEBUG)
-    sendForecast(DEBUG)
-    exit()
+try:
+    if DEBUG:
+        print(DEBUG)
+        sendForecast(DEBUG)
+        exit()
 
-myInternet = internet.Internet(IDTEXT)
-myInternet.connect(WIRE)
-myReader = morse.Reader(callback=readerCallback)
-mySender = morse.Sender(WPM)
-myKOB = kob.KOB(port=None, audio=False)
-myReader.setWPM(WPM)
-code = []
-bracket = False
-msg = ''
-while True:
-    try:
-        code += myInternet.read()
-        if code[-1] == 1:
-            log.log('Weather.py: {}'.format(code))
-            myReader.decode(code)
-            myReader.flush()
+    myInternet = internet.Internet(IDTEXT)
+    myInternet.connect(WIRE)
+    myReader = morse.Reader(callback=readerCallback)
+    mySender = morse.Sender(WPM)
+    myKOB = kob.KOB(port=None, audio=False)
+    myReader.setWPM(WPM)
+    code = []
+    bracket = False
+    msg = ''
+    while True:
+        try:
+            code += myInternet.read()
+            if code[-1] == 1:
+                log.log('Weather.py: {}'.format(code))
+                myReader.decode(code)
+                myReader.flush()
+                code = []
+                bracket = False
+                msg = ''
+        except:
+            log.err('Weather.py: Recovering from fatal error.')
+            time.sleep(30)
             code = []
             bracket = False
             msg = ''
-    except:
-        log.err('Weather.py: Recovering from fatal error.')
-        time.sleep(30)
-        code = []
-        bracket = False
-        msg = ''
+except KeyboardInterrupt:
+    print()
+    sys.exit(0)     # Since the main program is an infinite loop, ^C is a normal, successful exit.


### PR DESCRIPTION
I initially started trying to ensure a 'try: ... except:' block surrounded ALL executed statements, including 'import' but that got pretty messy so I abandoned that and reverted to changes ONLY in the main routine of a program.

I did in a few places separate out function definitions from their original location.

Comments welcome; if this looks OK I'll merge it later this week.  We can always tweak the code further if that's desirable.  This will NOT guarantee a ^C immediately on startup won't generate a traceback but should cleanly interrupt all main loops.