### PR TITLE
Change MKOB title bar and file extension

### DIFF
--- a/MKOB/MKOB.py
+++ b/MKOB/MKOB.py
@@ -25,11 +25,9 @@ SOFTWARE.
 """
 
 """
-
-MKOB.pyw
+MKOB.pyw  (Why does this say MKOB.pyw instead of MKOB.py? I don't remember. @leskerr)
 
 Python version of MorseKOB 2.5
-
 """
 
 import tkinter as tk
@@ -37,7 +35,7 @@ import kobwindow as kw
 import kobactions as ka
 import threading
 
-VERSION = 'MKOB 1.0.0'
+VERSION = "MorseKOB 4.0.0"
 
 root = tk.Tk()
 kw.KOBWindow(root, VERSION)

--- a/MKOB/MKOB.pyw
+++ b/MKOB/MKOB.pyw
@@ -25,7 +25,7 @@ SOFTWARE.
 """
 
 """
-MKOB.pyw  (Why does this say MKOB.pyw instead of MKOB.py? I don't remember. @leskerr)
+MKOB.pyw
 
 Python version of MorseKOB 2.5
 """

--- a/MKOB/setup.py
+++ b/MKOB/setup.py
@@ -1,7 +1,31 @@
+"""
+MIT License
+
+Copyright (c) 2020 PyKOB - MorseKOB in Python
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 from distutils.core import setup
 
-setup(name = 'MKOB',
-      version = '1.0.0',
+setup(name = 'MorseKOB',
+      version = '4.0.0',
       description = 'Python-based clone of MorseKOB 2.5',
       author = 'Les Kerr',
       author_email = 'les@morsekob.org',


### PR DESCRIPTION
Changed MKOB 1.0.0 to MorseKOB 4.0.0 in title bar and setup.py.  Also added license to setup.py.

It seems like a bad idea to have the version number in two separate places (MKOB.py and setup.py) but I don't know how to avoid this. If anyone has a better way we can fix it now, or I can open an issue to be dealt with later.