### PR TITLE
Processing of saved config values of 'STATION' and 'WIRE'.

### DIFF
--- a/pykob/config.py
+++ b/pykob/config.py
@@ -591,12 +591,12 @@ def read_config():
         __option = "Station"
         __key = __STATION_KEY
         _station = user_config.get(__CONFIG_SECTION, __key)
-        if not _station or _station.upper() == "NONE":
+        if (not _station) or (_station.upper() != "NONE"):
             station = _station
         __option = "Wire"
         __key = __WIRE_KEY
         _wire = user_config.get(__CONFIG_SECTION, __key)
-        if not _wire or _wire.upper() == "NONE":
+        if (not _wire) or (_wire.upper() != "NONE"):
             wire = _wire
     except KeyError as ex:
         log.err("Key '{}' not found in configuration file.".format(ex.args[0]))


### PR DESCRIPTION
@leskerr identified a problem in reading the 'station' and 'wire' parameters. Inspection showed that the values were saved correctly in the configuration file, but were not being read back correctly.

This fixes the processing of the '_STATION' and '_WIRE' key so that values of "NONE" or specific values are handled correctly.
