### PR TITLE
Lk 94 flag dropped packets

### DIFF
--- a/MKOB/kobmain.py
+++ b/MKOB/kobmain.py
@@ -136,10 +136,12 @@ def update_sender(id):
 
 def readerCallback(char, spacing):
     """display characters returned from the decoder"""
-    s = char
-    if spacing > 0.5:
-        s = " " + s
-    ka.codereader_append(s)
+    n = int(spacing + 0.5)
+    if n > 5:
+        sp = "__" if char != "~" else ""
+    else:
+        sp = n * " "
+    ka.codereader_append(sp + char)
 
 # initialization
 

--- a/pykob/morse.py
+++ b/pykob/morse.py
@@ -116,7 +116,7 @@ class Sender:
 """
 Code reader class
 
-Optional callback function is called whenever a character is decoded:
+Callback function is called whenever a character is decoded:
     def callback(char, spacing)
         char - decoded character
         spacing - spacing adjustment in space widths (can be negative)

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,6 +18,7 @@ These notes need to be fleshed out before MKOB is released.
 ### What's different
 
 - have to type ~ to open the wire when sending from the keyboard and + to close it
+- missing packets are indicated by a double underscore instead of an asterisk; long pauses also
 
 ### Known issues
 


### PR DESCRIPTION
MorseKOB 2.5 gave an indication of packets that had been dropped in the network by displaying an asterisk near where the packet was dropped (within a couple of characters). In the olden days, this happened fairly often, and operators would commonly ask each other whether they were "getting a lot of asterisks".

Networks are more reliable nowadays, although wireless connections are still a bit prone to the occasional dropped packet. It's nice to know when that has happened.

The change associated with this pull request flags dropped packets by displaying two underscores in the exact location where the character is missing in the text. This is an improvement. The way this is implemented in MKOB, the user also sees the same kind of double underscore when there's a long pause in the received Morse (longer than the equivalent of 5 spaces). It remains to be seen whether this will be well received by operators that are accustomed to MorseKOB 2.5's behavior. We'll find out once it goes into beta testing.