### PR TITLE
Esc key resets wire state

### DIFF
--- a/MKOB/MKOB.pyw
+++ b/MKOB/MKOB.pyw
@@ -34,7 +34,7 @@ import tkinter as tk
 import sys
 import kobwindow
 
-VERSION = "4.0.9"
+VERSION = "4.0.10"
 MKOB_VERSION_TEXT = "MorseKOB " + VERSION
 print(MKOB_VERSION_TEXT)
 

--- a/MKOB/kobactions.py
+++ b/MKOB/kobactions.py
@@ -96,3 +96,8 @@ def codereader_append(s):
     """append a string to the code reader window"""
     kw.txtReader.insert('end', s)
     kw.txtReader.yview_moveto(1)
+
+def escape(event):
+    """regain control of the wire"""
+    codereader_append("\n<Reset>")
+    km.reset_wire_state()

--- a/MKOB/kobmain.py
+++ b/MKOB/kobmain.py
@@ -165,6 +165,15 @@ def readerCallback(char, spacing):
     if char == "=":
         ka.codereader_append("\n")
 
+def reset_wire_state():
+    """log the current latching states and reinitialize"""
+    global kob_latched, keyboard_latched, internet_latched
+    print("Reset\n kob_latched: {}\n keyboard_latched: {}\n internet_latched: {}"
+            .format(kob_latched, keyboard_latched, internet_latched))
+    kob_latched = True
+    keyboard_latched = True
+    internet_latched = True
+
 # initialization
 
 if kc.Local:

--- a/MKOB/kobwindow.py
+++ b/MKOB/kobwindow.py
@@ -42,6 +42,7 @@ class KOBWindow:
         root.rowconfigure(0, weight=1)
         root.columnconfigure(0, weight=1)
         root.title(MKOB_VERSION_TEXT)
+        root.bind_all('<KeyPress-Escape>', ka.escape)
         ka.kw = self
         
         # File menu


### PR DESCRIPTION
MKOB can sometimes get into a state where the user is unable to send. This can occur when a remote user accidentally leaves their key open (does happen occasionally), the circuit closing packet from the remote user gets dropped in the network (very rare), or there's a bug in the program (if this is happening, it needs to be diagnosed and fixed).

The user can now regain control of the wire by pressing the Escape key. This resets the three latching state variables (`kob_latched`, `keyboard_latched`, and `internet_latched`) to their initial values (`True`). In addition, the value of these variables is logged to the console to aid in troubleshooting.