### PR TITLE
Add support for 'log.info()'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist*/
 zips/
 __pycache__/
 .DS_Store
+*.log
 *.pyo
 *.pyc
 *.toc

--- a/pykob/kob.py
+++ b/pykob/kob.py
@@ -60,7 +60,7 @@ class KOB:
                 self.port = serial.Serial(port)
                 self.port.dtr = True
             except:
-                log.info('Interface for key and sounder on serial port {} not available. Key and sounder will not be used.'.format(port))
+                log.info("Interface for key and sounder on serial port '{}' not available. Key and sounder will not be used.".format(port))
                 self.port = None
         else:
             self.port = None

--- a/pykob/log.py
+++ b/pykob/log.py
@@ -30,16 +30,25 @@ logs status, debug and error messages.
 import sys
 import datetime
 
-def log(msg, type='INFO'):
+def log(type, msg, dt=None):
+    dtl = dt if dt else str(datetime.datetime.now())[:19]
+    sys.stdout.write('{0} \t{1}: \t{2}\n'.format(dtl, type, msg))
+    sys.stdout.flush()
+
+def logErr(msg):
     dt = str(datetime.datetime.now())[:19]
+    log('ERROR', msg, dt) # Output to the normap output
     sys.stderr.write('{0} \t{1}: \t{2}\n'.format(dt, type, msg))
     sys.stderr.flush()
     
-def err(msg):
-    typ, val, trc = sys.exc_info()
-    log('{0}: \t({1})'.format(msg, val), type='ERROR')
-
 def debug(msg):
-    log(msg, type='DEBUG')
+    log('DEBUG', msg)
     sys.stderr.flush()
     
+def info(msg):
+    log('INFO', msg)
+    
+def err(msg):
+    typ, val, trc = sys.exc_info()
+    logErr('{0}: \t({1})'.format(msg, val), type='ERROR')
+


### PR DESCRIPTION
Updated the 'log' class to support ERR, INFO, DEBUG. Should look at a logging framework, but this works for now.