### PR TITLE
Remove `keytest.py`

### DIFF
--- a/keytest.py
+++ b/keytest.py
@@ -1,6 +1,0 @@
-from pykob import kob
-
-myKOB = kob.KOB(port="com3")
-myKOB.setSounder(False)
-while True:
-    print(myKOB.key())


### PR DESCRIPTION
This was a throwaway script that never belonged in the PyKOB project.