### PR TITLE
Implement code sender checkboxes

### DIFF
--- a/InstallModules.cmd
+++ b/InstallModules.cmd
@@ -1,0 +1,5 @@
+:: Windows command file to install the PyAudio and pySerial modules required by PyKOB.
+:: Python 3 must be installed first.
+
+py -m pip install pyaudio
+py -m pip install pyserial

--- a/MKOB/MKOB.cmd
+++ b/MKOB/MKOB.cmd
@@ -1,0 +1,1 @@
+py MKOB.pyw >MKOB.log 2>&1

--- a/MKOB/MKOB.pyw
+++ b/MKOB/MKOB.pyw
@@ -34,7 +34,7 @@ import tkinter as tk
 import sys
 import kobwindow
 
-VERSION = "4.0.12"
+VERSION = "4.0.13"
 MKOB_VERSION_TEXT = "MorseKOB " + VERSION
 print(MKOB_VERSION_TEXT)
 

--- a/MKOB/kobactions.py
+++ b/MKOB/kobactions.py
@@ -98,7 +98,7 @@ def doConnect():
 def codereader_append(s):
     """append a string to the code reader window"""
     kw.txtReader.insert('end', s)
-    kw.txtReader.yview_moveto(1)
+    kw.txtReader.see('end')
 
 def escape(event):
     """toggle Circuit Closer and regain control of the wire"""

--- a/MKOB/kobkeyboard.py
+++ b/MKOB/kobkeyboard.py
@@ -44,11 +44,15 @@ def keyboard_send():
     kw = ka.kw
     kw.txtKeyboard.tag_config('highlight', background='gray75',
             underline=0)
-    kw.txtKeyboard.tag_remove('highlight', '1.0', 'end')
     kw.txtKeyboard.mark_set('mark', '1.0')
+    kw.txtKeyboard.mark_gravity('mark', 'left')
     while True:
+        if kw.txtKeyboard.compare('mark', '==', 'end-1c') and \
+                kw.varCodeSenderRepeat.get():
+            kw.txtKeyboard.mark_set('mark', '1.0')
         if kw.txtKeyboard.compare('mark', '<', 'end-1c') and \
                 kw.varCodeSenderOn.get():
+            kw.txtKeyboard.see('mark')
             kw.txtKeyboard.tag_add('highlight', 'mark')
             c = kw.txtKeyboard.get('mark')
             if c == '~':

--- a/MKOB/kobwindow.py
+++ b/MKOB/kobwindow.py
@@ -101,10 +101,6 @@ class KOBWindow:
                 frm2, width=40, height=5, bd=2,
                 wrap='word', font=('Arial', -14))
         self.txtKeyboard.grid(row=0, column=0, sticky='NESW')
-        self.txtKeyboard.tag_config('highlight', underline=1)
-        self.txtKeyboard.mark_set('mark', '0.0')
-        self.txtKeyboard.mark_gravity('mark', 'left')
-        self.txtKeyboard.tag_add('highlight', 'mark')
         self.txtKeyboard.focus_set()
         
         # station list
@@ -142,12 +138,10 @@ class KOBWindow:
         self.varCodeSenderOn = tk.IntVar()
         chkCodeSenderOn = tk.Checkbutton(
                 lfm2, text='On', variable=self.varCodeSenderOn)
-        chkCodeSenderOn.config(state='disabled')  # TODO: temporary
         chkCodeSenderOn.grid(row=0, column=0, sticky='W')
         self.varCodeSenderRepeat = tk.IntVar()
         chkCodeSenderRepeat = tk.Checkbutton(
                 lfm2, text='Repeat', variable=self.varCodeSenderRepeat)
-        chkCodeSenderRepeat.config(state='disabled')  # TODO: temporary
         chkCodeSenderRepeat.grid(row=1, column=0, sticky='W')
 
         # wire no. / connect

--- a/pykob/SysCheck.cmd
+++ b/pykob/SysCheck.cmd
@@ -1,0 +1,1 @@
+py SysCheck.py >SysCheck.log 2>&1

--- a/pykob/log.py
+++ b/pykob/log.py
@@ -37,7 +37,7 @@ def log(type, msg, dt=None):
 
 def logErr(msg):
     dt = str(datetime.datetime.now())[:19]
-    log('ERROR', msg, dt) # Output to the normap output
+    log('ERROR', msg, dt) # Output to the normal output
     sys.stderr.write('{0} \t{1}: \t{2}\n'.format(dt, type, msg))
     sys.stderr.flush()
     
@@ -51,4 +51,3 @@ def info(msg):
 def err(msg):
     typ, val, trc = sys.exc_info()
     log('ERROR', '{0}: \t({1})'.format(msg, val))
-

--- a/pykob/syscheck.py
+++ b/pykob/syscheck.py
@@ -40,6 +40,13 @@ except:
     print('PyKOB not installed')
 
 try:
+    import pyaudio
+    pa = pyaudio.PyAudio()
+    print('PyAudio ' + pyaudio.get_portaudio_version_text())
+except:
+    print('PyAudio not installed')
+
+try:
     import serial
     print('pySerial ' + serial.VERSION)
     import serial.tools.list_ports
@@ -47,11 +54,3 @@ try:
         print(p[1])
 except:
     print('pySerial not installed')
-
-try:
-    import pyaudio
-    pa = pyaudio.PyAudio()
-    print('PyAudio ' + pyaudio.get_portaudio_version_text())
-except:
-    print('PyAudio not installed')
-


### PR DESCRIPTION
Implement `On` and `Repeat` controls for the keyboard.

Also, change the code reader window scrolling method from `yview_moveto` to `see`. If we're lucky, this will eliminate the jumping of the code reader window (issue #57).