### PR TITLE
Only put wire number in reader window during recording playback.

### DIFF
--- a/pykob/recorder.py
+++ b/pykob/recorder.py
@@ -171,7 +171,7 @@ class Recorder:
         """
         if self.__station_id != station_id:
             self.__station_id = station_id
-            if self.__play_station_id_callback:
+            if self.__play_station_id_callback and not self.playback_state == PlaybackState.idle:
                 self.__play_station_id_callback(station_id)
 
     @property
@@ -188,7 +188,7 @@ class Recorder:
         """
         if self.__wire != wire:
             self.__wire = wire
-            if self.__play_wire_callback:
+            if self.__play_wire_callback and not self.playback_state == PlaybackState.idle:
                 self.__play_wire_callback(wire)
 
     def record(self, code, source):


### PR DESCRIPTION
During playback of a recording it is nice to have the wire number displayed in the reader window at the beginning and when it changes. The recording was always calling the callback (even when not playing back) when the wire value changed.

This resolves that problem.