### PR TITLE
Playback - respect time delay between station changes.

### DIFF
--- a/MKOB/kobactions.py
+++ b/MKOB/kobactions.py
@@ -69,6 +69,7 @@ def doFilePlay():
             dirpath, filename = os.path.split(pf)
             codereader_append('[{}]'.format(filename))
             km.Recorder.playback_start(list_data=True, max_silence=5)
+    kw.make_keyboard_focus()
     
 def doFileExit():
     kw.root.destroy()
@@ -126,11 +127,53 @@ def codereader_clear():
     kw.txtReader.delete('1.0', 'end')
 
 def event_escape(event):
-    """toggle Circuit Closer and regain control of the wire"""
+    """
+    toggle Circuit Closer and regain control of the wire
+    """
     kw.varCircuitCloser.set(not kw.varCircuitCloser.get())
     doCircuitCloser()
     km.reset_wire_state()  # regain control of the wire
 
+def event_playback_move_back15(event):
+    """
+    Move the playback position back 15 seconds.
+    """
+    print("Playback - move back 15 seconds...")
+    if km.Recorder:
+        if km.Reader:
+            km.Reader.flush()  # Flush the Reader content before moving.
+        km.Recorder.playback_move_seconds(-15)
+
+def event_playback_move_forward15(event):
+    """
+    Move the playback position forward 15 seconds.
+    """
+    print("Playback - move forward 15 seconds...")
+    if km.Recorder:
+        if km.Reader:
+            km.Reader.flush()  # Flush the Reader content before moving.
+        km.Recorder.playback_move_seconds(15)
+        
+def event_playback_move_sender_start(event):
+    """
+    Move the playback position to the start of the current sender.
+    """
+    print("Playback - move to sender start...")
+    if km.Recorder:
+        if km.Reader:
+            km.Reader.flush()  # Flush the Reader content before moving.
+        km.Recorder.playback_move_to_sender_begin()
+        
+def event_playback_move_sender_end(event):
+    """
+    Move the playback position to the end of the current sender.
+    """
+    print("Playback - move to next sender...")
+    if km.Recorder:
+        if km.Reader:
+            km.Reader.flush()  # Flush the Reader content before moving.
+        km.Recorder.playback_move_to_sender_end()
+        
 def event_playback_pauseresume(event):
     """
     Pause/Resume a recording if currently playing/paused.

--- a/MKOB/kobwindow.py
+++ b/MKOB/kobwindow.py
@@ -46,6 +46,10 @@ class KOBWindow:
         root.bind_all('<KeyPress-Escape>', ka.event_escape)
         root.bind_all('<Control-KeyPress-s>', ka.event_playback_stop)
         root.bind_all('<Control-KeyPress-p>', ka.event_playback_pauseresume)
+        root.bind_all('<Control-KeyPress-h>', ka.event_playback_move_back15)
+        root.bind_all('<Control-KeyPress-l>', ka.event_playback_move_forward15)
+        root.bind_all('<Control-KeyPress-j>', ka.event_playback_move_sender_start)
+        root.bind_all('<Control-KeyPress-k>', ka.event_playback_move_sender_end)
         ka.kw = self
         
         # File menu
@@ -186,4 +190,10 @@ class KOBWindow:
 
         # Now that the windows and controls are initialized, initialize the kobmain module.
         kobmain.init()
+
+    def make_keyboard_focus(self):
+        """
+        Make the keyboard window the active (focused) window.
+        """
+        self.txtKeyboard.focus_set()
         

--- a/pykob/recorder.py
+++ b/pykob/recorder.py
@@ -349,21 +349,23 @@ class Recorder:
                         pause = 0
                         if codePause == 32.767 and len(code) > 1 and code[1] == 2:
                             # Probable sender change. See if it is...
-                            if not station == self.station_id:
-                                print("Sender change.")
-                            else:
-                                print("Dropped packet or other problem.")
+                            if self.__list_data:
+                                if not station == self.station_id:
+                                    print("Sender change.")
+                                else:
+                                    print("Dropped packet or other problem.")
                             pause = round((ts - self.__pblts)/1000, 4)
                         elif codePause > 2.0 and codePause < 32.767:
                             # Long pause in sent code
-                            pause = round((ts - self.__pblts)/1000, 4) - 2.0 # Subtract 2 seconds so kob has some to handle
+                            pause = round((((ts - self.__pblts)/1000) - 2.0), 4) # Subtract 2 seconds so kob has some to handle
                             code[0] = -2000  # Change pause in code sequence to 2 seconds since the rest is handled
                         if pause > 0:
                             # Long pause or a station/sender change.
                             # Pause for timestamp difference.
                             # For very long delays, sleep a maximum of `max_silence` seconds
                             if self.__max_silence > 0 and pause > self.__max_silence:
-                                print("Realtime pause of {} seconds being reduced to {} seconds".format(pause, self.__max_silence))
+                                if self.__list_data:
+                                    print("Realtime pause of {} seconds being reduced to {} seconds".format(pause, self.__max_silence))
                                 pause = self.__max_silence
                             if (not codePause == 32.767) and (pause > 2.0):
                                 pause -= 2.0 # Adjust the pause to allow the sounder and reader to do a 2 second pause


### PR DESCRIPTION
When a station change occurred the true (timestamp) delay wasn't being taken into account. This caused 'kob' to do a minimal delay which didn't reflect the actual time delay between the change of senders.

Test for station change and if one occurred do a delay based on the timestamp to be accurate.