### PR TITLE
Fix `Settings.cmd`

### DIFF
--- a/scripts/InstallMKOB.cmd
+++ b/scripts/InstallMKOB.cmd
@@ -15,7 +15,8 @@ del PyKOB.zip
 
 :: Create desktop shortcuts
 powershell "$s=(New-Object -COM WScript.Shell).CreateShortcut('%HomePath%\Desktop\MKOB4.lnk');$s.TargetPath='%HomePath%\Documents\MKOB4\PYKOB-master\scripts\MKOB.cmd';$s.WorkingDirectory='%HomePath%\Documents\MKOB4\PYKOB-master\scripts';$s.Save()"
-powershell "$s=(New-Object -COM WScript.Shell).CreateShortcut('%HomePath%\Desktop\MKOB4 Scripts.lnk');$s.TargetPath='%HomePath%\Documents\MKOB4\PYKOB-master\scripts';$s.Save()"
+::powershell "$s=(New-Object -COM WScript.Shell).CreateShortcut('%HomePath%\Desktop\MKOB4 Scripts.lnk');$s.TargetPath='c:\Users\Les\Documents\MKOB4\PyKOB-master\scripts';$s.Save()"
+powershell "$s=(New-Object -COM WScript.Shell).CreateShortcut('%HomePath%\Desktop\MKOB4 Scripts.lnk');$s.TargetPath='%HomePath%\Documents\MKOB4\PyKOB-master\scripts';$s.Save()"
 
 echo Installation complete.
 pause

--- a/scripts/Settings.cmd
+++ b/scripts/Settings.cmd
@@ -4,10 +4,10 @@
 set port=com3
 set /p port=Serial port (COM3): 
 set interface=loop
-set /p interface=Interface type (LOOP|key_sounder): 
+set /p interface=Interface type (LOOP^|key_sounder): 
 set audio=on
-set /p audio=Audio {ON|off): 
+set /p audio=Audio (ON^|off): 
 set sounder=on
-set /p audio=Sounder (ON|off): 
+set /p sounder=Sounder (ON^|off): 
 py ../Configure.py -p %port% -I %interface% -a %audio% -A %sounder%
 pause


### PR DESCRIPTION
Add caret to escape vertical bar in prompt strings.
Fix error in `sounder` setting.