### PR TITLE
Es 82 station list clear on wire change

### DIFF
--- a/kobmain.py
+++ b/kobmain.py
@@ -143,7 +143,9 @@ def toggle_connect():
     """connect or disconnect when user clicks on the Connect button"""
     global local_loop_active, internet_active
     global connected
+    global sender_ID
     if not connected:
+        sender_ID = ""
         ka.trigger_station_list_clear()
         Internet.monitor_IDs(ka.trigger_update_station_active) # Set callback for monitoring stations
         Internet.monitor_sender(ka.trigger_update_current_sender) # Set callback for monitoring current sender
@@ -158,28 +160,24 @@ def toggle_connect():
         if not local_loop_active:
             KOB.sounder(latch_code)
             Reader.decode(latch_code)
-            Reader.flush()
+        sender_ID = ""
         ka.trigger_station_list_clear()
     internet_active = False
 
 def change_wire():
-    global local_loop_active, internet_active
+    """
+    Change the current wire. If connected, drop the current connection and 
+    connect to the new wire.
+    """
     global connected
-    global sender_ID
-    if connected:
-        connected = False
-        Reader.flush()
-        if internet_active:
-            internet_active = False
-            if not local_loop_active:
-                KOB.sounder(latch_code)
-                Reader.decode(latch_code)
-                Reader.flush()
-        sender_ID = None
-        Internet.connect(kc.WireNo)
-        connected = True
+    # Disconnect, change wire, reconnect.
+    was_connected = connected
+    disconnect()
     Recorder.wire = kc.WireNo
-    internet_active = False
+    if was_connected:
+        time.sleep(0.350) # Needed to allow UTP packets to clear
+        toggle_connect()
+
     
 # callback functions
 

--- a/kobstationlist.py
+++ b/kobstationlist.py
@@ -114,8 +114,8 @@ def __trim_station_list() -> bool:
     now = time.time()
 
     # find and purge inactive stations
-    ## keep stations with ping time (element 3) within a minute of now
-    new_station_list = [row for row in __active_stations if row[3] > now - 60]
+    ## keep stations with ping time (element 3) within the last 2/3rds a minute
+    new_station_list = [row for row in __active_stations if row[3] > now - 40]
     station_removed = len(new_station_list) < len(__active_stations)
     __active_stations = new_station_list
     return station_removed

--- a/pykob/recorder.py
+++ b/pykob/recorder.py
@@ -588,6 +588,7 @@ class Recorder:
                             line = self.__p_fp.readline()
                             self.__p_line_no += 1
         finally:
+            self.__playback_stop_flag.set()
             self.__playback_state = PlaybackState.idle
             if self.__play_finished_callback:
                 self.__play_finished_callback()


### PR DESCRIPTION
For issue #82 there were two problems. First, if you had played a recording to the end, the station-list thread in the recorder-player kept running. This caused the stations from the recording to continue to be refreshed/added to the Station List. The second was that the connection to the wire was being changed with separate code from the Connect/Disconnect methods.

The changes are to:
1. Set the 'stop playback' flag when the playback completes normally (rather than being manually stopped).
2. Change the 'change wire' method to use the 'disconnect' and 'connect (toggle)' methods and also add clearing the 'sender ID' in the method.

This PR will CLOSE #82 
