### PR TITLE
Use posted messages to control Circuit Open/Close from Keyboard and Key

### DIFF
--- a/kobactions.py
+++ b/kobactions.py
@@ -126,6 +126,18 @@ def doConnect():
 #### Trigger event messages ###
 ####
 
+def trigger_circuit_close():
+    """
+    Generate an event to indicate that the circuit should be closed.
+    """
+    kw.root.event_generate(kobevents.EVENT_CIRCUIT_CLOSE, when='tail')
+
+def trigger_circuit_open():
+    """
+    Generate an event to indicate that the circuit should be opened.
+    """
+    kw.root.event_generate(kobevents.EVENT_CIRCUIT_OPEN, when='tail')
+
 def trigger_player_wire_change(id: int):
     """
     Generate an event to indicate that the wire number 
@@ -167,6 +179,18 @@ def trigger_update_station_active(id: str):
 ####
 #### Event (message) handlers
 ####
+
+def handle_circuit_close(event):
+    """
+    Close the circuit and trigger associated local functions (checkbox, etc.)
+    """
+    km.from_circuit_closer(True)
+
+def handle_circuit_open(event):
+    """
+    Open the circuit and trigger associated local functions (checkbox, sender, etc.)
+    """
+    km.from_circuit_closer(False)
 
 def handle_escape(event):
     """

--- a/kobevents.py
+++ b/kobevents.py
@@ -32,6 +32,8 @@ events.
 """
 
 # Define event messages
+EVENT_CIRCUIT_CLOSE = "<<Circuit_Close>>" # Close the local circuit
+EVENT_CIRCUIT_OPEN = "<<Circuit_Open>>" # Open the local circuit
 EVENT_CURRENT_SENDER = "<<Current_Sender>>" # Record the current sender (station)
 EVENT_PLAYER_WIRE_CHANGE = "<<Player_Wire_Change>>" # The player detected a wire change
 EVENT_READER_APPEND_TEXT = "<<Reader_Append_Text>>" # Append text to the reader window

--- a/kobkeyboard.py
+++ b/kobkeyboard.py
@@ -55,11 +55,12 @@ def keyboard_send():
             kw.txtKeyboard.tag_add('highlight', 'mark')
             c = kw.txtKeyboard.get('mark')
             if c == '~':
-                kw.varCircuitCloser.set(0)
-            code = km.Sender.encode(c)
-            km.from_keyboard(code)
-            if c == '+':
-                kw.varCircuitCloser.set(1)
+                ka.trigger_circuit_open()
+            elif c == '+':
+                ka.trigger_circuit_close()
+            else:
+                code = km.Sender.encode(c)
+                km.from_keyboard(code)
             kw.txtKeyboard.tag_remove('highlight', 'mark')
             kw.txtKeyboard.mark_set('mark', 'mark+1c')
         else:

--- a/kobmain.py
+++ b/kobmain.py
@@ -58,6 +58,10 @@ def __set_local_loop_active(state):
     """set local_loop_active state"""
     global local_loop_active
     local_loop_active = state
+    if local_loop_active:
+        if kc.config.interface_type == config.interface_type.loop:
+            KOB.setSounder(True)
+
 
 def __emit_code(code):
     """
@@ -94,8 +98,6 @@ def from_key(code):
             ka.trigger_circuit_open()
             return
     if not internet_active and local_loop_active:
-        if kc.config.interface_type == config.interface_type.loop:
-            KOB.setSounder(True)
         __emit_code(code)
 
 def from_keyboard(code):
@@ -153,10 +155,12 @@ def from_circuit_closer(state):
         Recorder.record(code, kob.CodeSource.local)
     if connected and kc.Remote:
         Internet.write(code)
-    if len(code) > 0 and code[-1] == +1:
+    if len(code) > 0 and code[-1] == 1:
+        # Unlatch
         __set_local_loop_active(False)
         Reader.flush()
     else:
+        # Latch
         __set_local_loop_active(True)
     ka.kw.varCircuitCloser.set(1 if not local_loop_active else 0)
 

--- a/kobwindow.py
+++ b/kobwindow.py
@@ -134,7 +134,7 @@ class KOBWindow:
         self.entOfficeID.bind('<Any-KeyRelease>', ka.doOfficeID)
         self.entOfficeID.grid(row=1, column=0, sticky='EW', padx=3, pady=6)
 
-        # circuit closer / WPM
+        # circuit closer
         lfm1 = tk.LabelFrame(frm4, padx=5, pady=5)
         lfm1.grid(row=0, column=0, columnspan=2, padx=3, pady=6)
         self.varCircuitCloser = tk.IntVar()
@@ -142,6 +142,7 @@ class KOBWindow:
                 lfm1, text='Circuit Closer', variable=self.varCircuitCloser,
                 command=ka.doCircuitCloser)
         chkCktClsr.grid(row=0, column=0)
+        # WPM
         tk.Label(lfm1, text='  WPM ').grid(row=0, column=1)
         self.spnWPM = tk.Spinbox(
                 lfm1, from_=5, to=40, justify='center',
@@ -177,9 +178,16 @@ class KOBWindow:
         self.btnConnect = tk.Button(lfm3, text='Connect', command=ka.doConnect)
         self.btnConnect.grid(row=2, columnspan=3, ipady=2, sticky='EW')
 
+        ###########################################################################################
         # Register messages and bind handlers
         ## For messages that need the 'data' element of an event
         ## need to use tk commands because tkinter doesn't provide wrapper methods.
+
+        #### Circuit Open/Close
+        self.root.bind(kobevents.EVENT_CIRCUIT_CLOSE, ka.handle_circuit_close)
+        self.root.bind(kobevents.EVENT_CIRCUIT_OPEN, ka.handle_circuit_open)
+        
+        #### Current Sender and Station List
         self.root.bind(kobevents.EVENT_STATIONS_CLEAR, ka.handle_clear_stations)
         ### self.root.bind(kobevents.EVENT_CURRENT_SENDER, ka.handle_sender_update)
         cmd = root.register(ka.handle_sender_update)
@@ -187,6 +195,8 @@ class KOBWindow:
         ### self.root.bind(kobevents.EVENT_STATION_ACTIVE, ksl.handle_update_station_active)
         cmd = root.register(ksl.handle_update_station_active)
         root.tk.call("bind", root, kobevents.EVENT_STATION_ACTIVE, cmd + " %d")
+
+        #### Reader
         self.root.bind(kobevents.EVENT_READER_CLEAR, ka.handle_reader_clear)
         ### self.root.bind(kobevents.EVENT_APPEND_TEXT, krdr.handle_append_text)
         cmd = root.register(ka.handle_reader_append_text)


### PR DESCRIPTION
I made changes to trigger messages to update the open/close state from the various mechanisms that could cause it.
I did significant testing with 5 stations connected to a wire... 2 MorseKOB-2.5 and 3 MKOB4.

All of the connect/disconnect seems to work in various combinations. This also fixes the issue that if you just start typing in the keyboard window or just start keying on the key - it would send regardless of whether the circuit is open or not (now the circuit must be open for anything to be sent).

I tested with both a loop and a separate key-sounder.

However, I made some changes that I'm not sure how to test with the loop. I compared 4.0 master functionality to this change and also with 2.5. I honestly don't know whether I broke something or not - but I will say that none seem to do what I expect as far as local sound goes when I am sending with a key.

@leskerr - I think this fixes the main issue, plus the issues of sending when you simply type something or key something (whether the circuit is open or closed). I would like you to spend time testing the different scenarios. At the same time, I'm not sure about the 'loop' mode in conjunction with a 'synth' sounder. The 'synth' sounder didn't follow the key (but testing with 'master' it doesn't seem to either).