### PR TITLE
Add text value to 'record' and record the decoded text

### DIFF
--- a/kobmain.py
+++ b/kobmain.py
@@ -194,6 +194,7 @@ def update_sender(id):
 
 def readerCallback(char, spacing):
     """display characters returned from the decoder"""
+    Recorder.record([], '', text=char)
     if kc.CodeType == config.CodeType.american:
         sp = (spacing - 0.25) / 1.25  # adjust for American Morse spacing
     else:

--- a/pykob/recorder.py
+++ b/pykob/recorder.py
@@ -34,7 +34,8 @@ The information is recorded in packets in a JSON structure that includes:
 3. Station ID
 4. Wire Number
 5. Code type
-6. Code Sequence (key timing information)
+6. The decoded character
+7. Code Sequence (key timing information)
 
 Though the name of the class is `recorder` it is typical that a 'recorder' can also
 play back. For example, a 'tape recorder', a 'video casset recorder (VCR)',
@@ -225,7 +226,7 @@ class Recorder:
         """
         self.__recorder_wire = wire
 
-    def record(self, code, source):
+    def record(self, code, source, text=''):
         """
         Record a code sequence in JSON format with additional context information.
         """
@@ -236,6 +237,7 @@ class Recorder:
                 "w":self.wire,
                 "s":self.station_id,
                 "o":source,
+                "t":text,
                 "c":code
             }
             with open(self.__target_file_path, "a+") as fp:
@@ -630,7 +632,7 @@ if __name__ == "__main__":
     # Append more text to the same file
     for c in "This is a test":
         codesequence = mySender.encode(c, True)
-        myRecorder.record(codesequence, kob.CodeSource.local)
+        myRecorder.record(codesequence, kob.CodeSource.local, c)
     print()
     # Play the file
     myKOB = kob.KOB(port=None, audio=True)


### PR DESCRIPTION
In the Reader's callback method (called once the code sequence(s) have been decoded) record the decoded text. Record it with an empty code sequence since that is already handled by the player by ignoring it.

Closes #214
