### PR TITLE
Add KOB Server URL config option to allow using an alternate server.

### DIFF
--- a/Configure.py
+++ b/Configure.py
@@ -64,6 +64,7 @@ def main(argv):
     local = None
     remote = None
     interface_type = None
+    server_url = None
     sound = None
     sounder = None
     spacing = None
@@ -85,6 +86,7 @@ def main(argv):
             config.min_char_speed_override, \
             config.remote_override, \
             config.serial_port_override, \
+            config.server_url_override, \
             config.sound_override, \
             config.sounder_override, \
             config.spacing_override, \
@@ -116,6 +118,13 @@ def main(argv):
             save_config = True
         if not args.serial_port == config.serial_port:
             config.set_serial_port(args.serial_port)
+            save_config = True
+        if not args.server_url == config.server_url:
+            s = config.server_url
+            if s and s.upper() == 'DEFAULT':
+                config.set_server_url(None)
+            else:
+                config.set_server_url(args.server_url)
             save_config = True
         if not args.sound == config.sound:
             config.set_sound(args.sound)

--- a/pykob/internet.py
+++ b/pykob/internet.py
@@ -32,10 +32,10 @@ import socket
 import struct
 import threading
 import time
-from pykob import VERSION, log
+from pykob import VERSION, config, log
 
-HOST = "mtc-kob.dyndns.org"
-PORT = 7890
+HOST_DEFAULT = "mtc-kob.dyndns.org"
+PORT_DEFAULT = 7890
 
 DIS = 2  # Disconnect
 DAT = 3  # Code or ID
@@ -50,8 +50,18 @@ NUL = '\x00'
 
 class Internet:
     def __init__(self, officeID, callback=None, record_callback=None):
+        self.host = HOST_DEFAULT
+        self.port = PORT_DEFAULT
+        s = config.server_url
+        if s:
+            # see if a port was included
+            # ZZZ error checking - should have 0 or 1 ':' and if port is included it should be numeric
+            hp = s.split(':',1)
+            if len(hp) == 2:
+                self.port = hp[1]
+            self.host = hp[0]
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.address = socket.getaddrinfo(HOST, PORT, socket.AF_INET,
+        self.address = socket.getaddrinfo(self.host, self.port, socket.AF_INET,
                 socket.SOCK_DGRAM)[0][4]
         self.version = ("PyKOB " + VERSION).encode(encoding='ascii')
         self.officeID = officeID if officeID != None else ""
@@ -141,7 +151,7 @@ class Internet:
 
     def sendID(self):
         try:
-            self.address = socket.getaddrinfo(HOST, PORT, socket.AF_INET,
+            self.address = socket.getaddrinfo(self.host, self.port, socket.AF_INET,
                     socket.SOCK_DGRAM)[0][4]
         except:
             log.info("PyKOB.internet ignoring DNS lookup error")


### PR DESCRIPTION
Added `server_url` to pykob.config. Added '-U url'/'--url url' to Configure.py. A value of 'NONE' or 'DEFAULT' results in the config.server_url value to be `None`, otherwise it will contain the value specified.

The pykob.internet class reads the URL value and if it's `None` it uses the default values (host = "mtc-kob.dyndns.org" and port = 7890). Otherwise it attempts to split the value on ':' to get a host and port value. If the URL doesn't include a port then the default port is used (7890).

Closes #31