### PR TITLE
Added try ... except around attempt to convert wire number with int(.…) in pykob/config.py:764

### DIFF
--- a/pykob/config.py
+++ b/pykob/config.py
@@ -761,7 +761,11 @@ def read_config():
         __key = __WIRE_KEY
         _wire = user_config.get(__CONFIG_SECTION, __key)
         if (_wire) or (_wire.upper() != "NONE"):
-            wire = int(_wire)
+            try:
+                wire = int(_wire)
+            except ValueError as ex:
+                log.err("Wire number value '{}' is not a valid integer value.".format(_wire))
+                wire = 1
     except KeyError as ex:
         log.err("Key '{}' not found in configuration file.".format(ex.args[0]))
         raise


### PR DESCRIPTION
Fix seems to only require adding a try ... except guard around the conversion attempt in pykob/configure.py.