### PR TITLE
Restore config.local since it is being used in kobmain.

### DIFF
--- a/pykob/config.py
+++ b/pykob/config.py
@@ -112,6 +112,7 @@ __AUTO_CONNECT_KEY = "AUTO_CONNECT"
 __CODE_TYPE_KEY = "CODE_TYPE"
 __INTERFACE_TYPE_KEY = "INTERFACE_TYPE"
 __INVERT_KEY_INPUT_KEY = "KEY_INPUT_INVERT"
+__LOCAL_KEY = "LOCAL"
 __MIN_CHAR_SPEED_KEY = "CHAR_SPEED_MIN"
 __REMOTE_KEY = "REMOTE"
 __SERVER_URL_KEY = "SERVER_URL"
@@ -152,6 +153,7 @@ auto_connect = False
 code_type = CodeType.american
 interface_type = InterfaceType.loop
 invert_key_input = False
+local = True
 remote = True
 server_url = None
 sound = True
@@ -565,6 +567,7 @@ def print_config():
     print("Code type:", code_type.name.upper())
     print("Interface type:", interface_type.name.upper())
     print("Invert key input:", onOffFromBool(invert_key_input))
+    print("Local copy:", onOffFromBool(local))
     print("Remote send:", onOffFromBool(remote))
     print("KOB Server URL:", url)
     print("Sound:", onOffFromBool(sound))
@@ -612,6 +615,7 @@ def read_config():
     global code_type
     global interface_type
     global invert_key_input
+    global local
     global min_char_speed
     global remote
     global server_url
@@ -670,6 +674,7 @@ def read_config():
         __CODE_TYPE_KEY:"AMERICAN", \
         __INTERFACE_TYPE_KEY:"LOOP", \
         __INVERT_KEY_INPUT_KEY:"OFF", \
+        __LOCAL_KEY:"ON", \
         __MIN_CHAR_SPEED_KEY:"18", \
         __REMOTE_KEY:"ON", \
         __SERVER_URL_KEY:"NONE", \
@@ -721,6 +726,9 @@ def read_config():
         __option = "Invert key input"
         __key = __INVERT_KEY_INPUT_KEY
         invert_key_input = user_config.getboolean(__CONFIG_SECTION, __key)
+        __option = "Local copy"
+        __key = __LOCAL_KEY
+        local = user_config.getboolean(__CONFIG_SECTION, __key)
         __option = "Minimum character speed"
         __key = __MIN_CHAR_SPEED_KEY
         min_char_speed = user_config.getint(__CONFIG_SECTION, __key)
@@ -793,6 +801,10 @@ help="The interface type (KEY_SOUNDER|LOOP|KEYER) to use.", metavar="interface-t
 invert_key_input_override = argparse.ArgumentParser(add_help=False)
 invert_key_input_override.add_argument("-M", "--iki", default=invert_key_input, \
 help="Enable/disable inverting the key input signal (used for dial-up/modem connections).", metavar="invert-key-input", dest="invert_key_input")
+
+local_override = argparse.ArgumentParser(add_help=False)
+local_override.add_argument("-L", "--local", default=local, \
+help="Enable/disable local copy of transmitted code.", metavar="local-copy", dest="local")
 
 min_char_speed_override = argparse.ArgumentParser(add_help=False)
 min_char_speed_override.add_argument("-c", "--charspeed", default=min_char_speed, type=int, \


### PR DESCRIPTION
Restoring the config.local property temporarily, as its removal causes an exception in kobmain when the circuit closer is opened.

Removal will be reviewed more closely in the changes to update the handling of the circuit closer.

Closes #241 