### PR TITLE
Pwd #243: limit to single preferences panel at runtime

### DIFF
--- a/kobactions.py
+++ b/kobactions.py
@@ -41,6 +41,8 @@ import kobstationlist as ksl
 import pykob  # for version number
 print("PyKOB " + pykob.VERSION)
 
+global preferencesDialog
+preferencesDialog = None
 kw = None  # initialized by KOBWindow
 
 ####
@@ -75,9 +77,18 @@ def doFilePlay():
         km.Recorder.playback_start(list_data=False, max_silence=5)
     kw.make_keyboard_focus()
 
+def _markPreferencesDestroyed(prefsDialog):
+    global preferencesDialog
+    preferencesDialog = None
+
 def doFilePreferences():
-    prefs = preferencesWindow.PreferencesWindow(quitWhenDismissed=False)
-    prefs.display()
+    global preferencesDialog
+
+    if not preferencesDialog:
+        preferencesDialog = \
+            preferencesWindow.PreferencesWindow(callback=_markPreferencesDestroyed,
+                                                quitWhenDismissed=False)
+    preferencesDialog.root.lift()
 
 def doFileExit():
     kw.root.destroy()

--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -306,7 +306,7 @@ class PreferencesWindow:
         self.root.mainloop()
 
     def dismiss(self):
-        if self._quitWhenDismissed:
+        if self._quitOnExit:
             self.root.quit()
         self.root.destroy()
         if self._callback:

--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -15,6 +15,10 @@ import serial.tools.list_ports
 global preferencesDialog
 preferencesDialog = None                # Force creation of a new dialog when first invoked
 
+#
+# 'callback' is invoked when the window is dismissed
+# 'quitWhenDismissed' forces an exit from the running Tkinter mainloop on exit
+#
 class PreferencesWindow:
     def __init__(self, callback=None, quitWhenDismissed=False):
         self._callback = callback

--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -12,9 +12,13 @@ from tkinter import Menu
 import serial
 import serial.tools.list_ports
 
+global preferencesDialog
+preferencesDialog = None                # Force creation of a new dialog when first invoked
+
 class PreferencesWindow:
-    def __init__(self, quitWhenDismissed=False):
-        self.quitOnExit = quitWhenDismissed
+    def __init__(self, callback=None, quitWhenDismissed=False):
+        self._callback = callback
+        self._quitOnExit = quitWhenDismissed
         config.read_config()
         print("Configured serial port  =", config.serial_port)
         print("Configured code speed  =", config.text_speed)
@@ -298,6 +302,8 @@ class PreferencesWindow:
         self.root.mainloop()
 
     def dismiss(self):
-        if self.quitOnExit:
+        if self._quitWhenDismissed:
             self.root.quit()
         self.root.destroy()
+        if self._callback:
+            self._callback(self)  


### PR DESCRIPTION
Change preferences logic to rely on running Tkinter mainloop() instead of starting a separate one; track preferences window and merely pull it to the front with root.lift() instead of creating another one.  Add support for a callback in the preferences window when it's dismissed (with 'Cancel' or 'Save') to help track the liveness of the preferences window.