### PR TITLE
Pwd 250 guard optional library inclusion and use

### DIFF
--- a/Configure.py
+++ b/Configure.py
@@ -31,7 +31,12 @@ Provides a Command Line Interface (CLI) the the pykob.config module.
 """
 import argparse
 import sys
-import tkinter as tk
+GUI = True                              # Hope for the best
+try:
+    import tkinter as tk
+except ModuleNotFoundError:
+    GUI = False
+    
 from pykob import config
 from pykob import preferencesWindow
 
@@ -102,7 +107,9 @@ def main(argv):
             config.station_override, \
             config.text_speed_override, \
             config.wire_override])
-        arg_parser.add_argument('-G', '--gui', dest="gui_config", action='store_true', help="Use preferences panel GUI for interactive configuration.")
+        if GUI:
+            arg_parser.add_argument('-G', '--gui', dest="gui_config", action='store_true',
+                            help="Use preferences panel GUI for interactive configuration.")
 
         args = arg_parser.parse_args()
 
@@ -162,7 +169,7 @@ def main(argv):
         print("Error processing arguments: {}".format(ex))
         sys.exit(1)
 
-    if args.gui_config:
+    if GUI and args.gui_config:
         try:
             root = tk.Tk()
             root.overrideredirect(1)

--- a/SysCheck.py
+++ b/SysCheck.py
@@ -54,3 +54,13 @@ try:
         print(p)
 except:
     print('pySerial not installed')
+
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+    from tkinter import scrolledtext
+    from tkinter import Menu
+    print('Tkinter ' + str(tk.TkVersion))
+except ModuleNotFound:
+    print('Tkinter not installed')

--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -4,13 +4,22 @@
 
 from pykob import config
 
-import tkinter as tk
-from tkinter import ttk
-from tkinter import scrolledtext
-from tkinter import Menu
+GUI = True                              # Hope for the best...
+try:
+    # import tkinter as tk
+    import X as tk
+    from tkinter import ttk
+    from tkinter import scrolledtext
+    from tkinter import Menu
+except ModuleNotFoundError:
+    GUI = False
 
-import serial
-import serial.tools.list_ports
+SERIAL = True                           # Hope for the best...
+try:
+    import serial
+    import serial.tools.list_ports
+except ModuleNotFoundError:
+    SERIAL = False
 
 global preferencesDialog
 preferencesDialog = None                # Force creation of a new dialog when first invoked
@@ -24,6 +33,9 @@ class PreferencesWindow:
         self._callback = callback
         self._quitOnExit = quitWhenDismissed
         config.read_config()
+        if not GUI:
+            return
+        
       # print("Configured serial port  =", config.serial_port)
       # print("Configured code speed  =", config.text_speed)
        
@@ -304,11 +316,13 @@ class PreferencesWindow:
         self.dismiss()
     
     def display(self):
-        self.root.mainloop()
+        if GUI:
+            self.root.mainloop()
 
     def dismiss(self):
-        if self._quitOnExit:
-            self.root.quit()
-        self.root.destroy()
+        if GUI:
+            if self._quitOnExit:
+                self.root.quit()
+            self.root.destroy()
         if self._callback:
             self._callback(self)  

--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -6,8 +6,7 @@ from pykob import config
 
 GUI = True                              # Hope for the best...
 try:
-    # import tkinter as tk
-    import X as tk
+    import tkinter as tk
     from tkinter import ttk
     from tkinter import scrolledtext
     from tkinter import Menu
@@ -79,12 +78,15 @@ class PreferencesWindow:
 
         # Add a pop-up menu with the list of available serial connections:
         self.serialPort = tk.StringVar()
-        systemSerialPorts = serial.tools.list_ports.comports()
-        serialPortValues = [systemSerialPorts[p].device for p in range(len(systemSerialPorts))]
+        if SERIAL:
+            systemSerialPorts = serial.tools.list_ports.comports()
+            serialPortValues = [systemSerialPorts[p].device for p in range(len(systemSerialPorts))]
+        else:
+            serialPortValues = []
         serialPortMenu = ttk.Combobox(localInterface,
                                       width=30,
                                       textvariable=self.serialPort,
-                                      state='readonly',
+                                      state='readonly' if SERIAL else 'disabled',
                                       values=serialPortValues).grid(row=1,
                                                                     column=0, columnspan=4,
                                                                     sticky=tk.W)
@@ -105,6 +107,7 @@ class PreferencesWindow:
         for serialadioButton in range(len(self.SERIAL_CONNECTION_TYPES)):
             ttk.Radiobutton(localInterface, text=self.SERIAL_CONNECTION_TYPES[serialadioButton],
                             variable=self.serialConnectionType,
+                            state='enabled' if SERIAL else 'disabled',
                             value=serialadioButton + 1).grid(row=serialadioButton + 2,
                                                              column=1, columnspan=2,
                                                              sticky=tk.W)


### PR DESCRIPTION
Updated references to Tkinter to be under guard; changed Configure.py to also disable -G option if no GUI support is available.  Changed pykob/preferencesWindow.py to not offer serial configuration if pySerial is not installed, and stub out any attempt to create a GUI window if Tkinter is not available.

No attempt to conditionalize Tkinter use in MKOB and its related source files (kobactions.py, kobwindow.py etc.)