### PR TITLE
Fix problem in master branch with un-tabbed references to preferenceswindow sections resulting in nearly empty preferences windows.

### DIFF
--- a/pykob/preferencesWindow.py
+++ b/pykob/preferencesWindow.py
@@ -101,7 +101,7 @@ class PreferencesWindow:
             serialPortValues = [systemSerialPorts[p].device for p in range(len(systemSerialPorts))]
         else:
             serialPortValues = []
-        serialPortMenu = ttk.Combobox(localInterface,
+        serialPortMenu = ttk.Combobox(basiclocalInterface,
                                       width=30,
                                       textvariable=self.serialPort,
                                       state='readonly' if SERIAL else 'disabled',


### PR DESCRIPTION
Looks like the merge of the tabbed window preferences mixed one of the older untapped references in the preferences code.  This should fix #249.