### PR TITLE
Correct values passed to morse.Reader.

### DIFF
--- a/Receive.py
+++ b/Receive.py
@@ -81,14 +81,14 @@ try:
         config.min_char_speed_override, \
         config.text_speed_override])
     arg_parser.add_argument('wire', nargs='?', default=config.wire, type=int,\
-        help='Wire to monitor. If specified, this is used rather than the one configured.')
+        help='Wire to monitor. If specified, this is used rather than the configured wire.')
     args = arg_parser.parse_args()
 
     port = args.serial_port # serial port for KOB interface
     useGpio = strtobool(args.gpio) # Use GPIO (Raspberry Pi)
 
     office_id = args.station # the Station/Office ID string to attach with
-    code_type = args.code_type
+    code_type = config.codeTypeFromString(args.code_type)
     spacing = args.spacing
     min_char_speed = args.min_char_speed
     text_speed = args.text_speed  # text speed (words per minute)
@@ -106,7 +106,7 @@ try:
     print('Connecting as Station/Office: ' + office_id)
 
     myInternet = internet.Internet(office_id)
-    myReader = morse.Reader(wpm=text_speed, code_type=code_type, callback=readerCallback)
+    myReader = morse.Reader(wpm=text_speed, codeType=code_type, callback=readerCallback)
     myKOB = kob.KOB(portToUse=port, useGpio=useGpio, useAudio=sound)
 
     myInternet.connect(wire)

--- a/pykob/config.py
+++ b/pykob/config.py
@@ -168,6 +168,15 @@ def noneOrValueFromStr(s):
     r = None if not s or not s.strip() or s.upper() == 'NONE' else s
     return r
 
+def codeTypeFromString(s):
+    """Return the CodeType for a string (A:AMERICAN|I:INTERNATIONAL). Raises a ValueError if not valid"""
+    s = s.upper()
+    if s=="A" or s=="AMERICAN":
+        return CodeType.american
+    elif s=="I" or s=="INTERNATIONAL":
+        return CodeType.international
+    raise ValueError(s)
+
 def create_config_files_if_needed():
     global app_config_dir
     global app_config_file_path


### PR DESCRIPTION
A named argument name was incorrect, and the value being passed was a string rather than an ENUM. Fixed both issues.