### PR TITLE
MRT - disconnect on exit. Add 'exit' method to classes with backgroun…

### DIFF
--- a/MRT.py
+++ b/MRT.py
@@ -64,6 +64,7 @@ internet_station_active = False  # True if a remote station is sending
 
 sender_current = ""
 last_received_para = False
+exit_status = 1
 
 def handle_sender_update(sender):
     """
@@ -243,7 +244,15 @@ try:
     while True:
         sleep(0.1)  # Loop while background threads take care of 'stuff'
 except KeyboardInterrupt:
+    exit_status = 0 # Since the main program is an infinite loop, ^C is a normal way to exit.
+finally:
     print()
     print()
-    sys.exit(0)     # Since the main program is an infinite loop, ^C is a normal, successful exit.
-
+    if connected:
+        Internet.disconnect()
+        sleep(0.3)
+    Reader.exit()
+    Internet.exit()
+    KOB.exit()
+    sleep(0.5)
+    sys.exit(exit_status)

--- a/pykob/morse.py
+++ b/pykob/morse.py
@@ -231,6 +231,14 @@ class Reader:
         self.flusher.setName("Reader-Flusher")
         self.flusher.start()
 
+    def exit(self):
+        """
+        Cancel the flusher (if it exists) and exit.
+        """
+        if self.flusher:
+            self.flusher.cancel()
+            self.flusher = None
+            
     def setWPM(self, wpm):
         self.wpm = wpm
         self.dotLen = int(1200. / wpm)


### PR DESCRIPTION
…d threads to signal them to stop/exit.

To help remove the station from the server when exiting. Disconnect and stop background threads when MRT is closed.