### PR TITLE
Feed - print some info on exit to help with debugging run problems.

### DIFF
--- a/Feed.py
+++ b/Feed.py
@@ -356,10 +356,12 @@ try:
     else:
         processRSS()
 except KeyboardInterrupt:
-    print()
+    print('.')
     sys.exit(0)     # Since normal operation is an infinite loop, ^C is actually a normal exit.
 except Exception as ex:
     print()
-    print(ex)
+    print("Feed encountered error: {}".format(ex))
     sys.exit(1)
-
+finally:
+    print("Goodbye")
+    print("")


### PR DESCRIPTION
I'm having some problems with Feed not starting correctly at times, but it's on a remote machine, so it is difficult to debug. Adding some print lines on exit to (hopefully) make it easier to tell why it is exiting.